### PR TITLE
URL Cleanup

### DIFF
--- a/obr-update/obr-update.sh
+++ b/obr-update/obr-update.sh
@@ -109,9 +109,9 @@ if [ ! -f $BINDEX_JAR ]; then
     if [ "$VERBOSE" = "1" ]; then
         WGET_OPTS="-v"
     fi
-    wget $WGET_OPTS --output-document=$BINDEX_JAR http://www.osgi.org/download/bindex.jar
+    wget $WGET_OPTS --output-document=$BINDEX_JAR https://www.osgi.org/download/bindex.jar
     if [[ ! "$?" = "0" ]]; then
-        l_error "wget was unable to download http://www.osgi.org/download/bindex.jar" >&2; exit 1;
+        l_error "wget was unable to download https://www.osgi.org/download/bindex.jar" >&2; exit 1;
     fi
     log "Downloaded $BINDEX_JAR"
 fi
@@ -211,7 +211,7 @@ log "Completed successfully"
 #               [-d rootdir ] 
 #               [-r repository.xml (.zip ext is ok)] 
 #               [-l file:license.html ] 
-#               [-t http://w.com/servl?s=%s&v=%v %s=symbolic-name
+#               [-t https://w.com/servl?s=%s&v=%v %s=symbolic-name
 #                       %v=version %p=relative path %f=name] 
 #               [-q (quiet) ]
 #               <jar file>*


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://spring-roo-repository.springsource.org/%p/%f (404) migrated to:  
  http://spring-roo-repository.springsource.org/%p/%f ([https](https://spring-roo-repository.springsource.org/%p/%f) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://w.com/servl?s=%s&v=%v (UnknownHostException) migrated to:  
  https://w.com/servl?s=%s&v=%v ([https](https://w.com/servl?s=%s&v=%v) result UnknownHostException).

## Fixed Success 
These URLs were fixed successfully.

* http://www.osgi.org/download/bindex.jar migrated to:  
  https://www.osgi.org/download/bindex.jar ([https](https://www.osgi.org/download/bindex.jar) result 301).